### PR TITLE
Accept OPML 1.0 and some other things

### DIFF
--- a/org-opml.el
+++ b/org-opml.el
@@ -2,7 +2,7 @@
 ;;
 ;; Change "~/src/org-opml/opml2org.py" to wherever that file is located.
 (add-to-list 'format-alist '(opml "Outline Processor Markup Language"
-                                  "<[?]xml version=\"1.0\"[?]>[\n]?.*[\n]?<opml version=\"2.0\">"
+                                  "<[?]xml version=\"1.0\"[^>]*[?]>[\n]?.*[\n]?.*[\n]?<opml version=\"[1|2].0\">"
                                   "~/src/org-opml/opml2org.py" opml-encode t))
 
 ;; If it ends with .opml, use `opml-encode' when saving.


### PR DESCRIPTION
Not sure how safe OPML 1.0 is with conversion, but it seems to work with
output from at least one tool that exports it.

This also accepts an encoding declaration on the xml header, and
steps past a comment intervening between the header and the start
of OPML (I'm not familiar with Emacs regexp, the latter tweak may not
really be needed).
