### PR TITLE
Be less strict when deciding if a file is OPML

### DIFF
--- a/org-opml.el
+++ b/org-opml.el
@@ -5,6 +5,10 @@
                                   "<[?]xml version=\"1.0\"[^>]*[?]>[\n]?.*[\n]?.*[\n]?<opml version=\"[1|2].0\">"
                                   "~/src/org-opml/opml2org.py" opml-encode t))
 
+(add-to-list 'format-alist '(opml "Outline Processor Markup Language"
+                                  "<opml version=[\"|\'][1|2].0[\"|\']>"
+                                  "~/src/org-opml/opml2org.py" opml-encode t))
+
 ;; If it ends with .opml, use `opml-encode' when saving.
 (defun set-buffer-file-format-to-opml ()
   "Set buffer-file-format to '(opml) when visiting an .opml file.


### PR DESCRIPTION
Some tools don't include the xml version header, so the OPML wasn't being detected as OPML.

Add a second entry to format-alist that looks for OPML declarations without xml version numbers to catch more OPML files.

Additionally, some tools use single quotes for the version number, so be a little looser about what that declaration looks like.
